### PR TITLE
Setting things up to test workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,8 @@ on: workflow_dispatch
 
 jobs:
   build:
+    name: merge checks
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3


### PR DESCRIPTION
Given this is a small project, running CI on every push is excessive. Instead, I will enforce a "developer must run tests successively before merging" policy. I am updating the workflow here to test in a subsequent PR.